### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
-## [1.0.0](https://github.com/donavanbecker/homebridge-air/compare/v0.1.0...v1.0.0) (2021-08-09)
+## [1.0.0](https://github.com/donavanbecker/homebridge-air/compare/v0.1.0...v1.0.0) (2024-XX-XX)
 
 ### What's Changes
 
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. This projec
 
 **Full Changelog**: https://github.com/donavanbecker/homebridge-air/compare/v0.1.0...v1.0.0
 
-## [0.1.0](https://github.com/donavanbecker/homebridge-air/releases/tag/v0.1.0) (2021-09-07)
+## [0.1.0](https://github.com/donavanbecker/homebridge-air/releases/tag/v0.1.0) (2024-09-07)
 
 ### What's Changes
 


### PR DESCRIPTION
## [1.0.0](https://github.com/donavanbecker/homebridge-air/compare/v0.1.0...v1.0.0) (2024-XX-XX)

### What's Changes

- Release of [homebridge-air](https://github.com/donavanbecker/homebridge-air) which allows you to update your see the air qualiry from AirNow Web API.

**Full Changelog**: https://github.com/donavanbecker/homebridge-air/compare/v0.1.0...v1.0.0