### PR TITLE
Setting refreshRate in json config to 1800 results in 5 hour update interval instead of 30 min

### DIFF
--- a/src/devices/airqualitysensor.ts
+++ b/src/devices/airqualitysensor.ts
@@ -73,7 +73,7 @@ export class AirQualitySensor extends deviceBase {
     this.refreshStatus()
 
     // Start an update interval
-    interval(this.deviceRefreshRate * 10000)
+    interval(this.deviceRefreshRate * 1000)
       .pipe(skipWhile(() => this.SensorUpdateInProgress))
       .subscribe(async () => {
         await this.refreshStatus()


### PR DESCRIPTION
Updated to ms interval.

## :recycle: Current situation

see https://github.com/homebridge-plugins/homebridge-air/issues/9

convert time from seconds to ms for RxJs interval function

## :bulb: Proposed solution

change constant from 10000 to 1000

## :gear: Release Notes

setting refreshRate in json config to 1800 results in 30 min update interval not 5 hours

## :heavy_plus_sign: Additional Information

N/A

### Testing

N/A

### Reviewer Nudging

line 76 of airQualitySensor.ts 
