### PR TITLE
Update AirNow API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. This projec
 - chore: allow dependency install scripts by package name rather than pinned version, so a version bump cannot silently block a native build
 - chore: exclude test files and the test config from the published package
 - fix: restore debug logging when the plugin runs in a child bridge
+- fix: update AirNow API
 
 ## v2.2.1 (2026-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ All notable changes to this project will be documented in this file. This projec
 - chore: allow dependency install scripts by package name rather than pinned version, so a version bump cannot silently block a native build
 - chore: exclude test files and the test config from the published package
 - fix: restore debug logging when the plugin runs in a child bridge
-- fix: update AirNow API
 
 ## v2.2.1 (2026-07-28)
 

--- a/src/devices/airqualitysensor.ts
+++ b/src/devices/airqualitysensor.ts
@@ -345,7 +345,7 @@ export class AirQualitySensor extends deviceBase {
       // https://docs.airnowapi.org/ObservationsByZipCodeLatLon/docs
       // Support flexible AQICN URL patterns: geo coordinates, city names, and full URL paths
       const AqicnCurrentObservationBy = resolveAqicnLocationSegment(this.device)
-      const AirNowCurrentObservationByValue = this.device.latitude && this.device.longitude ? `latitude=${this.device.latitude}&longitude=${this.device.longitude}` : `zipcode=${this.device.zipCode}`
+      const AirNowCurrentObservationByValue = this.device.latitude && this.device.longitude ? `latitude=${this.device.latitude}&longitude=${this.device.longitude}` : `zipCode=${this.device.zipCode}`
       const distance = this.device.distance || '25' // Default distance of 25 miles if not specified
       // Use correct format as per official AirNow API docs
       const providerUrls = {
@@ -381,7 +381,7 @@ export class AirQualitySensor extends deviceBase {
                 this.device.city = geoData.city
 
                 // Build new URL with zip code
-                const fallbackUrl = `${AirNowUrl}current/ziplatlong/?format=application/json&zipcode=${geoData.zipCode}&distance=${distance}&API_KEY=${this.device.apiKey}`
+                const fallbackUrl = `${AirNowUrl}current/ziplatlong/?format=application/json&zipCode=${geoData.zipCode}&distance=${distance}&API_KEY=${this.device.apiKey}`
                 await this.debugLog(`Fallback URL: ${fallbackUrl}`)
 
                 try {
@@ -431,7 +431,7 @@ export class AirQualitySensor extends deviceBase {
                 this.device.zipCode = geoData.zipCode
                 this.device.city = geoData.city
 
-                const fallbackUrl = `${AirNowUrl}current/ziplatlong/?format=application/json&zipcode=${geoData.zipCode}&distance=${distance}&API_KEY=${this.device.apiKey}`
+                const fallbackUrl = `${AirNowUrl}current/ziplatlong/?format=application/json&zipCode=${geoData.zipCode}&distance=${distance}&API_KEY=${this.device.apiKey}`
 
                 try {
                   const fallbackResponse = await this.executeApiRequestWithFallback(fallbackUrl)

--- a/src/devices/airqualitysensor.ts
+++ b/src/devices/airqualitysensor.ts
@@ -342,16 +342,14 @@ export class AirQualitySensor extends deviceBase {
       await this.debugLog(`API call ${this.apiCallCount}/${maxCallsPerHour} this hour`)
 
       // Use correct AirNow API endpoint paths from official docs
-      // https://docs.airnowapi.org/CurrentObservationsByZip/docs
-      // https://docs.airnowapi.org/CurrentObservationsByLatLon/docs
-      const AirNowCurrentObservationBy = this.device.latitude && this.device.longitude ? 'latLong' : 'zipCode'
+      // https://docs.airnowapi.org/ObservationsByZipCodeLatLon/docs
       // Support flexible AQICN URL patterns: geo coordinates, city names, and full URL paths
       const AqicnCurrentObservationBy = resolveAqicnLocationSegment(this.device)
-      const AirNowCurrentObservationByValue = this.device.latitude && this.device.longitude ? `latitude=${this.device.latitude}&longitude=${this.device.longitude}` : `zipCode=${this.device.zipCode}`
+      const AirNowCurrentObservationByValue = this.device.latitude && this.device.longitude ? `latitude=${this.device.latitude}&longitude=${this.device.longitude}` : `zipcode=${this.device.zipCode}`
       const distance = this.device.distance || '25' // Default distance of 25 miles if not specified
       // Use correct format as per official AirNow API docs
       const providerUrls = {
-        airnow: `${AirNowUrl}${AirNowCurrentObservationBy}/current/?format=application/json&${AirNowCurrentObservationByValue}&distance=${distance}&API_KEY=${this.device.apiKey}`,
+        airnow: `${AirNowUrl}current/ziplatlong/?format=application/json&${AirNowCurrentObservationByValue}&distance=${distance}&API_KEY=${this.device.apiKey}`,
         aqicn: `${AqicnUrl}${AqicnCurrentObservationBy}${AqicnCurrentObservationBy ? '/' : ''}?token=${this.device.apiKey}`,
       }
       const url = providerUrls[this.device.provider]
@@ -383,7 +381,7 @@ export class AirQualitySensor extends deviceBase {
                 this.device.city = geoData.city
 
                 // Build new URL with zip code
-                const fallbackUrl = `${AirNowUrl}ByZipCode/current/?format=application/json&zipCode=${geoData.zipCode}&distance=${distance}&API_KEY=${this.device.apiKey}`
+                const fallbackUrl = `${AirNowUrl}current/ziplatlong/?format=application/json&zipcode=${geoData.zipCode}&distance=${distance}&API_KEY=${this.device.apiKey}`
                 await this.debugLog(`Fallback URL: ${fallbackUrl}`)
 
                 try {
@@ -433,7 +431,7 @@ export class AirQualitySensor extends deviceBase {
                 this.device.zipCode = geoData.zipCode
                 this.device.city = geoData.city
 
-                const fallbackUrl = `${AirNowUrl}ByZipCode/current/?format=application/json&zipCode=${geoData.zipCode}&distance=${distance}&API_KEY=${this.device.apiKey}`
+                const fallbackUrl = `${AirNowUrl}current/ziplatlong/?format=application/json&zipcode=${geoData.zipCode}&distance=${distance}&API_KEY=${this.device.apiKey}`
 
                 try {
                   const fallbackResponse = await this.executeApiRequestWithFallback(fallbackUrl)

--- a/src/devices/airqualitysensormatter.ts
+++ b/src/devices/airqualitysensormatter.ts
@@ -157,7 +157,7 @@ export class AirQualitySensorMatter {
 
     const airNowByValue = this.device.latitude && this.device.longitude
       ? `latitude=${this.device.latitude}&longitude=${this.device.longitude}`
-      : `zipcode=${this.device.zipCode}`
+      : `zipCode=${this.device.zipCode}`
 
     const distance = this.device.distance || '25'
 

--- a/src/devices/airqualitysensormatter.ts
+++ b/src/devices/airqualitysensormatter.ts
@@ -153,18 +153,16 @@ export class AirQualitySensorMatter {
    * Build the provider API URL using the same logic as AirQualitySensor.refreshStatus.
    */
   private buildUrl(): string | undefined {
-    const airNowBy = this.device.latitude && this.device.longitude ? 'latLong' : 'zipCode'
-
     const aqicnBy = resolveAqicnLocationSegment(this.device)
 
     const airNowByValue = this.device.latitude && this.device.longitude
       ? `latitude=${this.device.latitude}&longitude=${this.device.longitude}`
-      : `zipCode=${this.device.zipCode}`
+      : `zipcode=${this.device.zipCode}`
 
     const distance = this.device.distance || '25'
 
     const urls: Record<string, string> = {
-      airnow: `${AirNowUrl}${airNowBy}/current/?format=application/json&${airNowByValue}&distance=${distance}&API_KEY=${this.device.apiKey}`,
+      airnow: `${AirNowUrl}current/ziplatlong/?format=application/json&${airNowByValue}&distance=${distance}&API_KEY=${this.device.apiKey}`,
       aqicn: `${AqicnUrl}${aqicnBy}${aqicnBy ? '/' : ''}?token=${this.device.apiKey}`,
     }
 


### PR DESCRIPTION
## :recycle: Current situation

per https://github.com/homebridge-plugins/homebridge-air/issues/84 the API for zipcode and lat long lookup has changed

## :bulb: Proposed solution

Update with new api

## :gear: Release Notes

Updated AirNow API per https://docs.airnowapi.org/ObservationsByZipCodeLatLon/docs

## :heavy_plus_sign: Additional Information

N/A

### Testing

N/A

### Reviewer Nudging
airqualitysensor.ts
airqualitysensormatter.ts